### PR TITLE
Fix Travis badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # green-rs
 
-[![Build Status](https://travis-ci.org/rust-lang/green-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/green-rs)
+[![Build Status](https://travis-ci.org/alexcrichton/green-rs.svg?branch=master)](https://travis-ci.org/alexcrichton/green-rs)
 
 Green scheduler and I/O for Rust
 


### PR DESCRIPTION
Previously, this was giving a 404.
